### PR TITLE
Fix non-quoted service string in YAML (deprecated)

### DIFF
--- a/src/DependencyInjection/config/error_listener.yml
+++ b/src/DependencyInjection/config/error_listener.yml
@@ -2,7 +2,7 @@ services:
     vasek_purchart.console_errors.console.console_error_listener:
         class: VasekPurchart\ConsoleErrorsBundle\Console\ConsoleErrorListener
         arguments:
-            - @vasek_purchart.console_errors.console.logger
+            - '@vasek_purchart.console_errors.console.logger'
         tags:
             -
                 name: kernel.event_listener

--- a/src/DependencyInjection/config/exception_listener.yml
+++ b/src/DependencyInjection/config/exception_listener.yml
@@ -2,11 +2,11 @@ services:
     vasek_purchart.console_errors.console.console_exception_listener:
         class: VasekPurchart\ConsoleErrorsBundle\Console\ConsoleExceptionListener
         arguments:
-            - @vasek_purchart.console_errors.console.logger
+            - '@vasek_purchart.console_errors.console.logger'
         tags:
             -
                 name: kernel.event_listener
                 event: console.exception
                 priority: %vasek_purchart.console_errors.exception.listener_priority%
 
-    vasek_purchart.console_errors.console.logger: @logger
+    vasek_purchart.console_errors.console.logger: '@logger'


### PR DESCRIPTION
Not quoting a scalar starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.
