### PR TITLE
Fix error logging when there is no command

### DIFF
--- a/src/Console/ConsoleExceptionListener.php
+++ b/src/Console/ConsoleExceptionListener.php
@@ -45,12 +45,14 @@ class ConsoleExceptionListener
 		$exception = $event->getError();
 
 		$message = sprintf(
-			'%s: %s (uncaught exception) at %s line %s while running console command `%s`',
+			'%s: %s (uncaught exception) at %s line %s%s',
 			get_class($exception),
 			$exception->getMessage(),
 			$exception->getFile(),
 			$exception->getLine(),
-			$command->getName()
+			$command !== null && $command->getName() !== null
+				? sprintf('while running console command `%s`', $command->getName())
+				: ''
 		);
 
 		$this->logger->log($this->logLevel, $message, [

--- a/tests/Console/ConsoleExceptionListenerTest.php
+++ b/tests/Console/ConsoleExceptionListenerTest.php
@@ -66,4 +66,31 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		);
 	}
 
+	/**
+	 * @dataProvider eventMethodProvider
+	 *
+	 * @param \Closure $methodCallback
+	 */
+	public function testLogErrorWithoutCommand(Closure $methodCallback): void
+	{
+		$message = 'Foobar!';
+		$exception = new \Exception($message);
+
+		$logLevel = LogLevel::DEBUG;
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger
+			->expects($this->once())
+			->method('log')
+			->with($logLevel, $this->stringContains($message), $this->contains($exception, true));
+
+		$input = $this->createMock(InputInterface::class);
+		$output = $this->createMock(OutputInterface::class);
+		$event = new ConsoleErrorEvent($input, $output, $exception, null);
+
+		$methodCallback(
+			new ConsoleExceptionListener($logger, $logLevel),
+			$event
+		);
+	}
+
 }


### PR DESCRIPTION
For example misspelled command name given.