### PR TITLE
Refactor tests

### DIFF
--- a/tests/Console/ConsoleExceptionListenerTest.php
+++ b/tests/Console/ConsoleExceptionListenerTest.php
@@ -20,7 +20,7 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return mixed[]|\Generator
 	 */
-	public function eventMethodProvider(): Generator
+	public function eventMethodDataProvider(): Generator
 	{
 		yield 'onConsoleError' => [
 			'methodCallback' => static function (ConsoleExceptionListener $listener, ConsoleErrorEvent $event): void {
@@ -36,7 +36,7 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider eventMethodProvider
+	 * @dataProvider eventMethodDataProvider
 	 *
 	 * @param \Closure $methodCallback
 	 */
@@ -68,7 +68,7 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider eventMethodProvider
+	 * @dataProvider eventMethodDataProvider
 	 *
 	 * @param \Closure $methodCallback
 	 */

--- a/tests/Console/ConsoleExceptionListenerTest.php
+++ b/tests/Console/ConsoleExceptionListenerTest.php
@@ -6,6 +6,7 @@ namespace VasekPurchart\ConsoleErrorsBundle\Console;
 
 use Closure;
 use Generator;
+use PHPUnit\Framework\Assert;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -48,12 +49,12 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		$logLevel = LogLevel::DEBUG;
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with($logLevel, $this->logicalAnd(
-				$this->stringContains($commandName),
-				$this->stringContains($message)
-			), $this->contains($exception, true));
+			->with($logLevel, Assert::logicalAnd(
+				Assert::stringContains($commandName),
+				Assert::stringContains($message)
+			), Assert::contains($exception, true));
 
 		$command = new Command($commandName);
 		$input = $this->createMock(InputInterface::class);
@@ -79,9 +80,9 @@ class ConsoleExceptionListenerTest extends \PHPUnit\Framework\TestCase
 		$logLevel = LogLevel::DEBUG;
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with($logLevel, $this->stringContains($message), $this->contains($exception, true));
+			->with($logLevel, Assert::stringContains($message), Assert::contains($exception, true));
 
 		$input = $this->createMock(InputInterface::class);
 		$output = $this->createMock(OutputInterface::class);

--- a/tests/Console/ConsoleExitCodeListenerTest.php
+++ b/tests/Console/ConsoleExitCodeListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\ConsoleErrorsBundle\Console;
 
+use PHPUnit\Framework\Assert;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -22,11 +23,11 @@ class ConsoleExitCodeListenerTest extends \PHPUnit\Framework\TestCase
 		$logLevel = LogLevel::DEBUG;
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with($logLevel, $this->logicalAnd(
-				$this->stringContains($commandName),
-				$this->stringContains((string) $exitCode)
+			->with($logLevel, Assert::logicalAnd(
+				Assert::stringContains($commandName),
+				Assert::stringContains((string) $exitCode)
 			));
 
 		$command = new Command($commandName);
@@ -46,11 +47,11 @@ class ConsoleExitCodeListenerTest extends \PHPUnit\Framework\TestCase
 		$logLevel = LogLevel::DEBUG;
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with($logLevel, $this->logicalAnd(
-				$this->stringContains($commandName),
-				$this->stringContains((string) 255)
+			->with($logLevel, Assert::logicalAnd(
+				Assert::stringContains($commandName),
+				Assert::stringContains((string) 255)
 			));
 
 		$command = new Command($commandName);
@@ -69,7 +70,7 @@ class ConsoleExitCodeListenerTest extends \PHPUnit\Framework\TestCase
 
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger
-			->expects($this->never())
+			->expects(self::never())
 			->method('log');
 
 		$command = new Command($commandName);

--- a/tests/Console/ConsoleExitCodeListenerTest.php
+++ b/tests/Console/ConsoleExitCodeListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\ConsoleErrorsBundle\Console;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
@@ -15,34 +16,34 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConsoleExitCodeListenerTest extends \PHPUnit\Framework\TestCase
 {
 
-	public function testLogError(): void
+	/**
+	 * @return int[][]|\Generator
+	 */
+	public function logErrorDataProvider(): Generator
 	{
-		$commandName = 'hello:world';
-		$exitCode = 123;
+		yield 'exit code lower than 255' => [
+			'exitCode' => 123,
+			'expectedExitCode' => 123,
+		];
 
-		$logLevel = LogLevel::DEBUG;
-		$logger = $this->createMock(LoggerInterface::class);
-		$logger
-			->expects(self::once())
-			->method('log')
-			->with($logLevel, Assert::logicalAnd(
-				Assert::stringContains($commandName),
-				Assert::stringContains((string) $exitCode)
-			));
-
-		$command = new Command($commandName);
-		$input = $this->createMock(InputInterface::class);
-		$output = $this->createMock(OutputInterface::class);
-		$event = new ConsoleTerminateEvent($command, $input, $output, $exitCode);
-
-		$listener = new ConsoleExitCodeListener($logger, $logLevel);
-		$listener->onConsoleTerminate($event);
+		yield 'max exit code is 255' => [
+			'exitCode' => 999,
+			'expectedExitCode' => 255,
+		];
 	}
 
-	public function testLogErrorExitCodeMax255(): void
+	/**
+	 * @dataProvider logErrorDataProvider
+	 *
+	 * @param int $exitCode
+	 * @param int $expectedExitCode
+	 */
+	public function testLogError(
+		int $exitCode,
+		int $expectedExitCode
+	): void
 	{
 		$commandName = 'hello:world';
-		$exitCode = 999;
 
 		$logLevel = LogLevel::DEBUG;
 		$logger = $this->createMock(LoggerInterface::class);
@@ -51,7 +52,7 @@ class ConsoleExitCodeListenerTest extends \PHPUnit\Framework\TestCase
 			->method('log')
 			->with($logLevel, Assert::logicalAnd(
 				Assert::stringContains($commandName),
-				Assert::stringContains((string) 255)
+				Assert::stringContains((string) $expectedExitCode)
 			));
 
 		$command = new Command($commandName);

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -111,11 +111,26 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function logLevelDataProvider(): Generator
 	{
-		yield ['error', 'error'];
-		yield ['debug', 'debug'];
-		yield ['ERROR', 'error'];
-		yield [100, 100];
-		yield [999, 999];
+		yield [
+			'error',
+			'error',
+		];
+		yield [
+			'debug',
+			'debug',
+		];
+		yield [
+			'ERROR',
+			'error',
+		];
+		yield [
+			100,
+			100,
+		];
+		yield [
+			999,
+			999,
+		];
 	}
 
 	/**
@@ -145,10 +160,18 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function invalidLogLevelDataProvider(): Generator
 	{
-		yield ['lorem'];
-		yield ['LOREM'];
-		yield [100.0];
-		yield [null];
+		yield [
+			'lorem',
+		];
+		yield [
+			'LOREM',
+		];
+		yield [
+			100.0,
+		];
+		yield [
+			null,
+		];
 	}
 
 	/**

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -68,11 +68,11 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		yield [
+		yield 'listener_priority' => [
 			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
 			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
 		];
-		yield [
+		yield 'log_level' => [
 			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
 			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
 		];
@@ -111,23 +111,23 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function logLevelDataProvider(): Generator
 	{
-		yield [
+		yield 'lowercase error (as PSR-3 uses)' => [
 			'inputLogLevel' => 'error',
 			'normalizedValueLogLevel' => 'error',
 		];
-		yield [
+		yield 'lowercase debug (as PSR-3 uses)' => [
 			'inputLogLevel' => 'debug',
 			'normalizedValueLogLevel' => 'debug',
 		];
-		yield [
+		yield 'uppercase error (as Monolog uses)' => [
 			'inputLogLevel' => 'ERROR',
 			'normalizedValueLogLevel' => 'error',
 		];
-		yield [
+		yield 'integer based on Monolog value' => [
 			'inputLogLevel' => 100,
 			'normalizedValueLogLevel' => 100,
 		];
-		yield [
+		yield 'arbitrary integer' => [
 			'inputLogLevel' => 999,
 			'normalizedValueLogLevel' => 999,
 		];
@@ -160,16 +160,16 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function invalidLogLevelDataProvider(): Generator
 	{
-		yield [
+		yield 'nonexistent log level as lowercase string' => [
 			'inputLogLevel' => 'lorem',
 		];
-		yield [
+		yield 'nonexistent log level as uppercase string' => [
 			'inputLogLevel' => 'LOREM',
 		];
-		yield [
+		yield 'float value' => [
 			'inputLogLevel' => 100.0,
 		];
-		yield [
+		yield 'null value' => [
 			'inputLogLevel' => null,
 		];
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -65,7 +65,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]
 	 */
-	public function defaultConfigurationValuesProvider(): array
+	public function defaultConfigurationValuesDataProvider(): array
 	{
 		return [
 			[
@@ -80,7 +80,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationValuesProvider
+	 * @dataProvider defaultConfigurationValuesDataProvider
 	 *
 	 * @param string $parameterName
 	 * @param mixed $parameterValue
@@ -110,7 +110,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]
 	 */
-	public function logLevelProvider(): array
+	public function logLevelDataProvider(): array
 	{
 		return [
 			['error', 'error'],
@@ -122,7 +122,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider logLevelProvider
+	 * @dataProvider logLevelDataProvider
 	 *
 	 * @param string|int $inputLogLevel
 	 * @param string|int $normalizedValueLogLevel
@@ -146,7 +146,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]
 	 */
-	public function invalidLogLevelProvider(): array
+	public function invalidLogLevelDataProvider(): array
 	{
 		return [
 			['lorem'],
@@ -157,7 +157,7 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider invalidLogLevelProvider
+	 * @dataProvider invalidLogLevelDataProvider
 	 *
 	 * @param string|int $inputLogLevel
 	 */

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -74,49 +74,6 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): Generator
-	{
-		yield 'listener_priority' => [
-			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
-			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
-		];
-		yield 'log_level' => [
-			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
-			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
-		];
-	}
-
-	/**
-	 * @dataProvider defaultConfigurationValuesDataProvider
-	 *
-	 * @param string $parameterName
-	 * @param mixed $parameterValue
-	 */
-	public function testDefaultConfigurationValues(string $parameterName, $parameterValue): void
-	{
-		$this->load();
-
-		$this->assertContainerBuilderHasParameter($parameterName, $parameterValue);
-
-		$this->compile();
-	}
-
-	public function testConfigureListenerPriority(): void
-	{
-		$this->load([
-			'exceptions' => [
-				'listener_priority' => 123,
-			],
-		]);
-
-		$this->assertContainerBuilderHasParameter(ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY, 123);
-
-		$this->compile();
-	}
-
-	/**
-	 * @return mixed[][]|\Generator
-	 */
 	public function logLevelDataProvider(): Generator
 	{
 		yield 'lowercase error (as PSR-3 uses)' => [
@@ -142,23 +99,61 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider logLevelDataProvider
-	 *
-	 * @param string|int $inputLogLevel
-	 * @param string|int $normalizedValueLogLevel
+	 * @return mixed[][]|\Generator
 	 */
-	public function testConfigureLogLevel($inputLogLevel, $normalizedValueLogLevel): void
+	public function configureContainerParameterDataProvider(): Generator
 	{
-		$this->load([
-			'exceptions' => [
-				'log_level' => $inputLogLevel,
-			],
-		]);
+		yield 'default listener_priority' => [
+			'configuration' => [],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
+			'expectedParameterValue' => Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
+		];
 
-		$this->assertContainerBuilderHasParameter(
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
-			$normalizedValueLogLevel
-		);
+		yield 'default log_level' => [
+			'configuration' => [],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
+			'expectedParameterValue' => Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
+		];
+
+		yield 'configure listener_priority' => [
+			'configuration' => [
+				'exceptions' => [
+					'listener_priority' => 123,
+				],
+			],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
+			'expectedParameterValue' => 123,
+		];
+
+		foreach ($this->logLevelDataProvider() as $caseName => $caseData) {
+			yield 'configure log_level - ' . $caseName => [
+				'configuration' => [
+					'exceptions' => [
+						'log_level' => $caseData['inputLogLevel'],
+					],
+				],
+				'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
+				'expectedParameterValue' => $caseData['normalizedValueLogLevel'],
+			];
+		}
+	}
+
+	/**
+	 * @dataProvider configureContainerParameterDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string $parameterName
+	 * @param mixed $expectedParameterValue
+	 */
+	public function testConfigureContainerParameter(
+		array $configuration,
+		string $parameterName,
+		$expectedParameterValue
+	): void
+	{
+		$this->load($configuration);
+
+		$this->assertContainerBuilderHasParameter($parameterName, $expectedParameterValue);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -69,12 +69,12 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
 		yield [
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
-			Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
+			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
 		];
 		yield [
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
-			Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
+			'parameterValue' => Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
 		];
 	}
 
@@ -112,24 +112,24 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	public function logLevelDataProvider(): Generator
 	{
 		yield [
-			'error',
-			'error',
+			'inputLogLevel' => 'error',
+			'normalizedValueLogLevel' => 'error',
 		];
 		yield [
-			'debug',
-			'debug',
+			'inputLogLevel' => 'debug',
+			'normalizedValueLogLevel' => 'debug',
 		];
 		yield [
-			'ERROR',
-			'error',
+			'inputLogLevel' => 'ERROR',
+			'normalizedValueLogLevel' => 'error',
 		];
 		yield [
-			100,
-			100,
+			'inputLogLevel' => 100,
+			'normalizedValueLogLevel' => 100,
 		];
 		yield [
-			999,
-			999,
+			'inputLogLevel' => 999,
+			'normalizedValueLogLevel' => 999,
 		];
 	}
 
@@ -161,16 +161,16 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	public function invalidLogLevelDataProvider(): Generator
 	{
 		yield [
-			'lorem',
+			'inputLogLevel' => 'lorem',
 		];
 		yield [
-			'LOREM',
+			'inputLogLevel' => 'LOREM',
 		];
 		yield [
-			100.0,
+			'inputLogLevel' => 100.0,
 		];
 		yield [
-			null,
+			'inputLogLevel' => null,
 		];
 	}
 

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -20,9 +20,34 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 		];
 	}
 
-	public function testExceptionsEnabledByDefault(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function exceptionsEnabledDataProvider(): Generator
 	{
-		$this->load();
+		yield 'exceptions enabled by default' => [
+			'configuration' => [],
+		];
+
+		yield 'exceptions enabled by configuration' => [
+			'configuration' => [
+				'exceptions' => [
+					'enabled' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider exceptionsEnabledDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 */
+	public function testExceptionsEnabled(
+		array $configuration
+	): void
+	{
+		$this->load($configuration);
 
 		$this->assertContainerBuilderHasService('vasek_purchart.console_errors.console.console_exception_listener', ConsoleExceptionListener::class);
 		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.console_errors.console.console_exception_listener', 'kernel.event_listener', [
@@ -42,23 +67,6 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 		]);
 
 		$this->assertContainerBuilderNotHasService('vasek_purchart.console_errors.console.console_exception_listener');
-
-		$this->compile();
-	}
-
-	public function testExceptionsEnabled(): void
-	{
-		$this->load([
-			'exceptions' => [
-				'enabled' => true,
-			],
-		]);
-
-		$this->assertContainerBuilderHasService('vasek_purchart.console_errors.console.console_exception_listener', ConsoleExceptionListener::class);
-		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.console_errors.console.console_exception_listener', 'kernel.event_listener', [
-			'event' => 'console.error',
-			'priority' => '%' . ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY . '%',
-		]);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExceptionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\ConsoleErrorsBundle\DependencyInjection;
 
+use Generator;
 use VasekPurchart\ConsoleErrorsBundle\Console\ConsoleExceptionListener;
 
 class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
@@ -63,19 +64,17 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): array
+	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		return [
-			[
-				ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
-				Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
-			],
-			[
-				ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
-				Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
-			],
+		yield [
+			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LISTENER_PRIORITY,
+			Configuration::DEFAULT_EXCEPTION_LISTENER_PRIORITY,
+		];
+		yield [
+			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXCEPTION_LOG_LEVEL,
+			Configuration::DEFAULT_EXCEPTION_LOG_LEVEL,
 		];
 	}
 
@@ -108,17 +107,15 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function logLevelDataProvider(): array
+	public function logLevelDataProvider(): Generator
 	{
-		return [
-			['error', 'error'],
-			['debug', 'debug'],
-			['ERROR', 'error'],
-			[100, 100],
-			[999, 999],
-		];
+		yield ['error', 'error'];
+		yield ['debug', 'debug'];
+		yield ['ERROR', 'error'];
+		yield [100, 100];
+		yield [999, 999];
 	}
 
 	/**
@@ -144,16 +141,14 @@ class ConsoleErrorsExtensionExceptionsTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function invalidLogLevelDataProvider(): array
+	public function invalidLogLevelDataProvider(): Generator
 	{
-		return [
-			['lorem'],
-			['LOREM'],
-			[100.0],
-			[null],
-		];
+		yield ['lorem'];
+		yield ['LOREM'];
+		yield [100.0];
+		yield [null];
 	}
 
 	/**

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -74,49 +74,6 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): Generator
-	{
-		yield 'listener_priority' => [
-			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
-			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
-		];
-		yield 'log_level' => [
-			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
-			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
-		];
-	}
-
-	/**
-	 * @dataProvider defaultConfigurationValuesDataProvider
-	 *
-	 * @param string $parameterName
-	 * @param mixed $parameterValue
-	 */
-	public function testDefaultConfigurationValues(string $parameterName, $parameterValue): void
-	{
-		$this->load();
-
-		$this->assertContainerBuilderHasParameter($parameterName, $parameterValue);
-
-		$this->compile();
-	}
-
-	public function testConfigureListenerPriority(): void
-	{
-		$this->load([
-			'exit_code' => [
-				'listener_priority' => 123,
-			],
-		]);
-
-		$this->assertContainerBuilderHasParameter(ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY, 123);
-
-		$this->compile();
-	}
-
-	/**
-	 * @return mixed[][]|\Generator
-	 */
 	public function logLevelDataProvider(): Generator
 	{
 		yield 'lowercase error (as PSR-3 uses)' => [
@@ -142,23 +99,61 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @dataProvider logLevelDataProvider
-	 *
-	 * @param string|int $inputLogLevel
-	 * @param string|int $normalizedValueLogLevel
+	 * @return mixed[][]|\Generator
 	 */
-	public function testConfigureLogLevel($inputLogLevel, $normalizedValueLogLevel): void
+	public function configureContainerParameterDataProvider(): Generator
 	{
-		$this->load([
-			'exit_code' => [
-				'log_level' => $inputLogLevel,
-			],
-		]);
+		yield 'default listener_priority' => [
+			'configuration' => [],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
+			'expectedParameterValue' => Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
+		];
 
-		$this->assertContainerBuilderHasParameter(
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
-			$normalizedValueLogLevel
-		);
+		yield 'default log_level' => [
+			'configuration' => [],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
+			'expectedParameterValue' => Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
+		];
+
+		yield 'configure listener_priority' => [
+			'configuration' => [
+				'exit_code' => [
+					'listener_priority' => 123,
+				],
+			],
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
+			'expectedParameterValue' => 123,
+		];
+
+		foreach ($this->logLevelDataProvider() as $caseName => $caseData) {
+			yield 'configure log_level - ' . $caseName => [
+				'configuration' => [
+					'exit_code' => [
+						'log_level' => $caseData['inputLogLevel'],
+					],
+				],
+				'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
+				'expectedParameterValue' => $caseData['normalizedValueLogLevel'],
+			];
+		}
+	}
+
+	/**
+	 * @dataProvider configureContainerParameterDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string $parameterName
+	 * @param mixed $expectedParameterValue
+	 */
+	public function testConfigureContainerParameter(
+		array $configuration,
+		string $parameterName,
+		$expectedParameterValue
+	): void
+	{
+		$this->load($configuration);
+
+		$this->assertContainerBuilderHasParameter($parameterName, $expectedParameterValue);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -65,7 +65,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	/**
 	 * @return mixed[][]
 	 */
-	public function defaultConfigurationValuesProvider(): array
+	public function defaultConfigurationValuesDataProvider(): array
 	{
 		return [
 			[
@@ -80,7 +80,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationValuesProvider
+	 * @dataProvider defaultConfigurationValuesDataProvider
 	 *
 	 * @param string $parameterName
 	 * @param mixed $parameterValue
@@ -110,7 +110,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	/**
 	 * @return mixed[][]
 	 */
-	public function logLevelProvider(): array
+	public function logLevelDataProvider(): array
 	{
 		return [
 			['error', 'error'],
@@ -122,7 +122,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @dataProvider logLevelProvider
+	 * @dataProvider logLevelDataProvider
 	 *
 	 * @param string|int $inputLogLevel
 	 * @param string|int $normalizedValueLogLevel
@@ -146,7 +146,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	/**
 	 * @return mixed[][]
 	 */
-	public function invalidLogLevelProvider(): array
+	public function invalidLogLevelDataProvider(): array
 	{
 		return [
 			['lorem'],
@@ -157,7 +157,7 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @dataProvider invalidLogLevelProvider
+	 * @dataProvider invalidLogLevelDataProvider
 	 *
 	 * @param string|int $inputLogLevel
 	 */

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\ConsoleErrorsBundle\DependencyInjection;
 
+use Generator;
 use VasekPurchart\ConsoleErrorsBundle\Console\ConsoleExitCodeListener;
 
 class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
@@ -63,19 +64,17 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): array
+	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		return [
-			[
-				ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
-				Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
-			],
-			[
-				ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
-				Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
-			],
+		yield [
+			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
+			Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
+		];
+		yield [
+			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
+			Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
 		];
 	}
 
@@ -108,17 +107,15 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function logLevelDataProvider(): array
+	public function logLevelDataProvider(): Generator
 	{
-		return [
-			['error', 'error'],
-			['debug', 'debug'],
-			['ERROR', 'error'],
-			[100, 100],
-			[999, 999],
-		];
+		yield ['error', 'error'];
+		yield ['debug', 'debug'];
+		yield ['ERROR', 'error'];
+		yield [100, 100];
+		yield [999, 999];
 	}
 
 	/**
@@ -144,16 +141,14 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function invalidLogLevelDataProvider(): array
+	public function invalidLogLevelDataProvider(): Generator
 	{
-		return [
-			['lorem'],
-			['LOREM'],
-			[100.0],
-			[null],
-		];
+		yield ['lorem'];
+		yield ['LOREM'];
+		yield [100.0];
+		yield [null];
 	}
 
 	/**

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -20,9 +20,34 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 		];
 	}
 
-	public function testErrorsEnabledByDefault(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function errorsEnabledDataProvider(): Generator
 	{
-		$this->load();
+		yield 'errors enabled by default' => [
+			'configuration' => [],
+		];
+
+		yield 'errors enabled by configuration' => [
+			'configuration' => [
+				'exit_code' => [
+					'enabled' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider errorsEnabledDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 */
+	public function testErrorsEnabled(
+		array $configuration
+	): void
+	{
+		$this->load($configuration);
 
 		$this->assertContainerBuilderHasService('vasek_purchart.console_errors.console.console_exit_code_listener', ConsoleExitCodeListener::class);
 		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.console_errors.console.console_exit_code_listener', 'kernel.event_listener', [
@@ -42,23 +67,6 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 		]);
 
 		$this->assertContainerBuilderNotHasService('vasek_purchart.console_errors.console.console_exit_code_listener');
-
-		$this->compile();
-	}
-
-	public function testErrorsEnabled(): void
-	{
-		$this->load([
-			'exit_code' => [
-				'enabled' => true,
-			],
-		]);
-
-		$this->assertContainerBuilderHasService('vasek_purchart.console_errors.console.console_exit_code_listener', ConsoleExitCodeListener::class);
-		$this->assertContainerBuilderHasServiceDefinitionWithTag('vasek_purchart.console_errors.console.console_exit_code_listener', 'kernel.event_listener', [
-			'event' => 'console.terminate',
-			'priority' => '%' . ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY . '%',
-		]);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -111,11 +111,26 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	 */
 	public function logLevelDataProvider(): Generator
 	{
-		yield ['error', 'error'];
-		yield ['debug', 'debug'];
-		yield ['ERROR', 'error'];
-		yield [100, 100];
-		yield [999, 999];
+		yield [
+			'error',
+			'error',
+		];
+		yield [
+			'debug',
+			'debug',
+		];
+		yield [
+			'ERROR',
+			'error',
+		];
+		yield [
+			100,
+			100,
+		];
+		yield [
+			999,
+			999,
+		];
 	}
 
 	/**
@@ -145,10 +160,18 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	 */
 	public function invalidLogLevelDataProvider(): Generator
 	{
-		yield ['lorem'];
-		yield ['LOREM'];
-		yield [100.0];
-		yield [null];
+		yield [
+			'lorem',
+		];
+		yield [
+			'LOREM',
+		];
+		yield [
+			100.0,
+		];
+		yield [
+			null,
+		];
 	}
 
 	/**

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -68,11 +68,11 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	 */
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		yield [
+		yield 'listener_priority' => [
 			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
 			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
 		];
-		yield [
+		yield 'log_level' => [
 			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
 			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
 		];
@@ -111,23 +111,23 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	 */
 	public function logLevelDataProvider(): Generator
 	{
-		yield [
+		yield 'lowercase error (as PSR-3 uses)' => [
 			'inputLogLevel' => 'error',
 			'normalizedValueLogLevel' => 'error',
 		];
-		yield [
+		yield 'lowercase debug (as PSR-3 uses)' => [
 			'inputLogLevel' => 'debug',
 			'normalizedValueLogLevel' => 'debug',
 		];
-		yield [
+		yield 'uppercase error (as Monolog uses)' => [
 			'inputLogLevel' => 'ERROR',
 			'normalizedValueLogLevel' => 'error',
 		];
-		yield [
+		yield 'integer based on Monolog value' => [
 			'inputLogLevel' => 100,
 			'normalizedValueLogLevel' => 100,
 		];
-		yield [
+		yield 'arbitrary integer' => [
 			'inputLogLevel' => 999,
 			'normalizedValueLogLevel' => 999,
 		];
@@ -160,16 +160,16 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	 */
 	public function invalidLogLevelDataProvider(): Generator
 	{
-		yield [
+		yield 'nonexistent log level as lowercase string' => [
 			'inputLogLevel' => 'lorem',
 		];
-		yield [
+		yield 'nonexistent log level as uppercase string' => [
 			'inputLogLevel' => 'LOREM',
 		];
-		yield [
+		yield 'float value' => [
 			'inputLogLevel' => 100.0,
 		];
-		yield [
+		yield 'null value' => [
 			'inputLogLevel' => null,
 		];
 	}

--- a/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
+++ b/tests/DependencyInjection/ConsoleErrorsExtensionExitCodeTest.php
@@ -69,12 +69,12 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
 		yield [
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
-			Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LISTENER_PRIORITY,
+			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LISTENER_PRIORITY,
 		];
 		yield [
-			ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
-			Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
+			'parameterName' => ConsoleErrorsExtension::CONTAINER_PARAMETER_EXIT_CODE_LOG_LEVEL,
+			'parameterValue' => Configuration::DEFAULT_EXIT_CODE_LOG_LEVEL,
 		];
 	}
 
@@ -112,24 +112,24 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	public function logLevelDataProvider(): Generator
 	{
 		yield [
-			'error',
-			'error',
+			'inputLogLevel' => 'error',
+			'normalizedValueLogLevel' => 'error',
 		];
 		yield [
-			'debug',
-			'debug',
+			'inputLogLevel' => 'debug',
+			'normalizedValueLogLevel' => 'debug',
 		];
 		yield [
-			'ERROR',
-			'error',
+			'inputLogLevel' => 'ERROR',
+			'normalizedValueLogLevel' => 'error',
 		];
 		yield [
-			100,
-			100,
+			'inputLogLevel' => 100,
+			'normalizedValueLogLevel' => 100,
 		];
 		yield [
-			999,
-			999,
+			'inputLogLevel' => 999,
+			'normalizedValueLogLevel' => 999,
 		];
 	}
 
@@ -161,16 +161,16 @@ class ConsoleErrorsExtensionExitCodeTest extends \Matthias\SymfonyDependencyInje
 	public function invalidLogLevelDataProvider(): Generator
 	{
 		yield [
-			'lorem',
+			'inputLogLevel' => 'lorem',
 		];
 		yield [
-			'LOREM',
+			'inputLogLevel' => 'LOREM',
 		];
 		yield [
-			100.0,
+			'inputLogLevel' => 100.0,
 		];
 		yield [
-			null,
+			'inputLogLevel' => null,
 		];
 	}
 


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks